### PR TITLE
Added handling for unrecognized firewalld service failure

### DIFF
--- a/roles/rke2_common/tasks/main.yml
+++ b/roles/rke2_common/tasks/main.yml
@@ -51,6 +51,11 @@
     state: stopped
     enabled: no
   when: ansible_facts.services["firewalld.service"] is defined
+  register: service_command_output
+  failed_when: >
+    service_command_output is failed
+    and 'unrecognized service' not in service_command_output.msg
+    and 'Could not find the requested service' not in service_command_output
 
 - include: network_manager_fix.yaml
 

--- a/roles/rke2_common/tasks/main.yml
+++ b/roles/rke2_common/tasks/main.yml
@@ -50,12 +50,7 @@
     name: firewalld
     state: stopped
     enabled: no
-  when: ansible_facts.services["firewalld.service"] is defined
-  register: service_command_output
-  failed_when: >
-    service_command_output is failed
-    and 'unrecognized service' not in service_command_output.msg
-    and 'Could not find the requested service' not in service_command_output
+  when: ansible_facts.services["firewalld.service"] is defined and ansible_facts.services["firewalld.service"].status != "not-found"
 
 - include: network_manager_fix.yaml
 


### PR DESCRIPTION
## What type of PR is this?

- [x] bug
- [ ] cleanup
- [ ] documentation
- [ ] feature

## What this PR does / why we need it:

If a node has Docker installed, we run into an error where Ansible service facts collects the firewalld service since it is referred to as a dependency but actually isn't present on the machine. This means it is technically "defined" but any attempts to interact with the service will fail. This handling allows us to fail on any errors other than the service not being found, in which case we carry on (since firewalld is very much not running at that point).

## Which issue(s) this PR fixes:

Undocumented issue: when Docker is installed on the node, the following error is encountered when attempting the "disable FIREWALLD" task (Ubuntu 18.04): 
`"failed: Could not find the requested service firewalld: host"`

## Release Notes

```release-note
Fixes issue where firewalld is defined in Ansible service facts if Docker is installed on the node due to a dependency, but the firewalld service is unrecognized/not found.
```

