### PR TITLE
Hostname override regex rejects hostnames prefixed with numbers

### DIFF
--- a/roles/rke2_server/tasks/other_servers.yml
+++ b/roles/rke2_server/tasks/other_servers.yml
@@ -58,7 +58,7 @@
     - name: Extract the hostname-override parameter from the kubelet process
       set_fact:
         kubelet_hostname_override_parameter: "{{ kubelet_check.stdout |\
-          regex_search('\\s--hostname-override=((([a-zA-Z]|[a-zA-Z][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z]|[A-Za-z][A-Za-z0-9\\-]*[A-Za-z0-9]))\\s',\
+          regex_search('\\s--hostname-override=((([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9]))\\s',\
           '\\1') }}"
 
     - name: Wait for node to show Ready status


### PR DESCRIPTION
Hostname overrides are now consistent with the first_server task.

<!--
  This template provides some ideas of things to include in your PR description.
  To start, try providing a short summary of your changes in the Title above.
  If a section of the PR template does not apply to this PR, then delete that section.
 -->

## What type of PR is this?

_(REQUIRED)_

- [x] bug
- [ ] cleanup
- [ ] documentation
- [ ] feature

## What this PR does / why we need it:

_(REQUIRED)_

<!--
  What goal is this change working towards?
  Provide a bullet pointed summary of how each file was changed.
  Briefly explain any decisions you made with respect to the changes.
  Include anything here that you didn't include in *Release Notes*
  above, such as changes to CI or changes to internal methods.
-->
- Modified hostname override regex in other_servers to be consistent with first_server (which does not reject hostnames prefixed with numbers).

## Which issue(s) this PR fixes:

_(REQUIRED)_
<!--
If this PR fixes one of more issues, list them here.
One line each, like so:

Fixes #123
Fixes #39
-->

## Release Notes

_(REQUIRED)_
<!--
  If this PR makes user facing changes, please describe them here. This
  description will be copied into the release notes/changelog, whenever the
  next version is released. Keep this section short, and focus on high level
  changes.

  Put your text between the block. To omit notes, use NONE within the block.
-->

```release-note

```

